### PR TITLE
Fix application bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5136,8 +5136,6 @@
             // Update analytics
             updateAnalytics(filteredEntries);
         }
-        // Local storage for entries (encrypted)
-        let entries = getEncryptedStorage('cardiacEntries', []);
         // Form submission with validation, toast, pinned, etc.
         document.getElementById('dataForm').addEventListener('submit', function (e) {
             e.preventDefault();


### PR DESCRIPTION
Remove problematic initialization of `entries` from encrypted local storage to fix an application bug.

The line `let entries = getEncryptedStorage('cardiacEntries', []);` was causing the application to fail, likely due to `getEncryptedStorage` not being defined or accessible at the point of execution, or an incorrect approach to managing `entries`. Removing it resolves the issue preventing the app from working.

---
<a href="https://cursor.com/background-agent?bcId=bc-569cc398-409a-4036-845e-4590f2368b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-569cc398-409a-4036-845e-4590f2368b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

